### PR TITLE
name must consist of lower case alphanumeric characters

### DIFF
--- a/k8s-manifests/apps/cluster-wide-app-resources/prometheus-snmp-exporter.yaml
+++ b/k8s-manifests/apps/cluster-wide-app-resources/prometheus-snmp-exporter.yaml
@@ -25,7 +25,7 @@ spec:
         serviceMonitor:
           enabled: true
           params:
-            - name: TST-X510
+            - name: tst-x510
               target: 172.16.19.253
               module:
                 - if_mib


### PR DESCRIPTION
argocdのエラー:

```txt
Failed sync attempt to 1.1.0: one or more objects failed to apply, reason: ServiceMonitor.monitoring.coreos.com "prometheus-snmp-exporter-TST-X510" is invalid: metadata.name: Invalid value: "prometheus-snmp-exporter-TST-X510": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*') (retried 5 times).
```